### PR TITLE
Add depth loss instead of depth diff

### DIFF
--- a/src_train/anchor.py
+++ b/src_train/anchor.py
@@ -148,7 +148,7 @@ class A2J_loss(nn.Module):
                     0.5 * (1/3) * torch.pow(regression_diff_depth, 2),
                     regression_diff_depth - 0.5 / (1/3)
                     )
-                regression_loss += regression_diff_depth.mean()           
+                regression_loss += regression_loss_depth.mean()           
 ############################################################
             regression_losses.append(regression_loss)
         return torch.stack(anchor_regression_loss_tuple).mean(dim=0, keepdim=True), torch.stack(regression_losses).mean(dim=0, keepdim=True)   


### PR DESCRIPTION
Lines 131 and 141 add losses for anchors and XY coords respectively. Line 151, on the other hand, adds regression_diff_depth. In order to match the other lines, it should instead add regression_loss_depth.